### PR TITLE
Add missing comma.

### DIFF
--- a/org.kde.kclock.json
+++ b/org.kde.kclock.json
@@ -27,7 +27,7 @@
                 { 
                     "type": "archive", 
                     "url": "https://download.kde.org/unstable/kirigami-addons/0.2/kirigami-addons-0.2.tar.xz",
-                    "sha256": "f8be68831c3261cfd2ffd84b61530cdf84c9cc5f26101d0c48e185b7f0017092"
+                    "sha256": "f8be68831c3261cfd2ffd84b61530cdf84c9cc5f26101d0c48e185b7f0017092",
                     "x-checker-data": {
                         "type": "anitya",
                         "project-id": 242933,


### PR DESCRIPTION
I was trying to rebuild a bunch of flatpaks on my side and I noticed this one has a malformed manifest. Turns out there is just a missing comma which I added in this PR.